### PR TITLE
Remove net471 as target framework.

### DIFF
--- a/Rivers.Test/Rivers.Test.csproj
+++ b/Rivers.Test/Rivers.Test.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFrameworks>net471;netcoreapp2.2</TargetFrameworks>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference Include="..\Rivers\Rivers.csproj" />

--- a/Rivers/Rivers.csproj
+++ b/Rivers/Rivers.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>Rivers</Title>
         <Version>0.1.0.0</Version>
         <Copyright>Copyright 2018 Washi</Copyright>


### PR DESCRIPTION
This project only requires netstandard2.0 and can therefore skip the
net471 as target framework.

And the test project is more cross-platform friendly without net471
as target framework.